### PR TITLE
Add modular scalping research pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # scalping_strategy_development
-## develop potential profitable scalping strategy  like human by reading market profile and utilize order flow analysis
+
+Research repository for building event-driven scalping strategies using
+Topstep futures data.  The code base now includes a modular pipeline that
+handles data loading, exploratory analysis, signal generation and
+backtesting.
+
+See [docs/PIPELINE.md](docs/PIPELINE.md) for details on the architecture
+and how to extend each component.
+
+## Quick Start
+
+```bash
+python -m pipeline.run_pipeline path/to/md_CON_F_US_EP_U25_20250811.duckdb outputs
+```
+
+The command above loads data, builds signals and runs a queue based
+backtest.  Resulting events and trade summaries are written to the
+`outputs` directory.
+
+## Disclaimer
+
+This repository is for research and educational purposes.  Use at your
+own risk and always validate strategies on your own data before
+considering live trading.
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -1,0 +1,53 @@
+# Event-Driven Scalping Research Pipeline
+
+This repository provides a minimal yet extendable pipeline for building
+and backtesting event-driven scalping strategies.  The design follows a
+"think big, do small" philosophy: every step is modular and can be
+validated independently before moving to the next stage.
+
+## Steps
+
+1. **Data Loading** – `pipeline.data.load_raw_events`
+   - Reads the raw Topstep DuckDB files and reconstructs per-event order
+     book snapshots.
+   - Output: DataFrame with best bid/ask, volumes, trade-through and
+     cancel statistics.
+
+2. **Exploratory Analysis** – `pipeline.explore.basic_stats`
+   - Computes lightweight descriptive statistics used by human scalpers.
+   - Intended for sanity checks before feature engineering.
+
+3. **Signal Construction** – `pipeline.signals.build_signals`
+   - Applies event-based primitives (break-outs, vacuum cancels and
+     aggressor imbalance) to produce directional signals and edge
+     estimates.
+   - Parameters mirror those used by experienced discretionary traders
+     and can be tuned for different markets.
+
+4. **Backtesting** – `pipeline.backtest.run_backtest`
+   - Simulates queue-based execution using the generated signals.
+   - Supports maker, taker and hybrid entries with configurable
+     protections.
+
+5. **Orchestration** – `pipeline.run_pipeline`
+   - Command line entry point that ties the above steps together and
+     writes events, trades and summary statistics to an output folder.
+
+## Usage
+
+```bash
+python -m pipeline.run_pipeline <path-to-db> output_dir \
+    --start 2025-08-11T13:00:00Z --end 2025-08-11T14:00:00Z
+```
+
+Each module can also be imported independently for iterative research in
+interactive environments or notebooks.
+
+## Next Steps
+
+- Perform deeper statistical validation on generated signals.
+- Experiment with alternative event primitives or machine-learning based
+  scoring models.
+- Integrate brokerage execution or paper trading to move from research
+  to deployment.
+

--- a/pipeline/backtest.py
+++ b/pipeline/backtest.py
@@ -1,0 +1,49 @@
+"""Backtesting helpers."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+import pandas as pd
+
+from event_driven_strategy import backtest_with_queue
+
+
+def run_backtest(
+    events_with_signals: pd.DataFrame,
+    hold_sec: float = 5.0,
+    queue_pos: float = 10.0,
+    stop_ticks: float = 0.0,
+    tp_ticks: float = 0.0,
+    trail_ticks: float = 0.0,
+    min_hold_ms: int = 0,
+    entry_mode: str = "maker",
+    taker_slip_ticks: int = 1,
+    time_stop_ms: int = 2000,
+    pullback_ticks: int = 1,
+    dwell_ms: int = 200,
+    fill_timeout_ms: int = 600,
+    min_pullback_l1: float = 1.0,
+    hybrid_taker_edge: float = 3.0,
+) -> Dict[str, Any]:
+    """Run queue-based backtest using pre-computed signals."""
+    if events_with_signals.empty:
+        return {"trades": pd.DataFrame(), "summary": {}}
+    result = backtest_with_queue(
+        events_with_signals,
+        hold_sec=hold_sec,
+        queue_pos=queue_pos,
+        stop_ticks=stop_ticks,
+        tp_ticks=tp_ticks,
+        trail_ticks=trail_ticks,
+        min_hold_ms=min_hold_ms,
+        entry_mode=entry_mode,
+        taker_slip_ticks=taker_slip_ticks,
+        time_stop_ms=time_stop_ms,
+        pullback_ticks=pullback_ticks,
+        dwell_ms=dwell_ms,
+        fill_timeout_ms=fill_timeout_ms,
+        min_pullback_l1=min_pullback_l1,
+        hybrid_taker_edge=hybrid_taker_edge,
+    )
+    return result
+

--- a/pipeline/data.py
+++ b/pipeline/data.py
@@ -1,0 +1,45 @@
+"""Data access and preprocessing utilities for scalping pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple, Optional
+
+import pandas as pd
+
+from event_driven_strategy import load_topstep_data, reconstruct_order_book_with_depth
+
+
+def load_raw_events(
+    db_path: str,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    max_depth: int = 10,
+    quote_default_l1_size: float = 2.0,
+) -> pd.DataFrame:
+    """Load raw data from DuckDB and reconstruct event level order book.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the DuckDB database.
+    start_time, end_time:
+        Optional time bounds (UTC ISO format).
+    max_depth:
+        Depth of order book to reconstruct.
+    quote_default_l1_size:
+        Default size when quote stream reports zero at L1.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Event-level snapshots with best bid/ask, volume information and
+        trade/cancel counts. See :func:`event_driven_strategy.reconstruct_order_book_with_depth`.
+    """
+    depth_df, quotes_df = load_topstep_data(db_path, start_time, end_time)
+    if depth_df.empty and quotes_df.empty:
+        return pd.DataFrame()
+    events = reconstruct_order_book_with_depth(
+        depth_df, quotes_df, max_depth=max_depth, quote_default_l1_size=quote_default_l1_size
+    )
+    return events
+

--- a/pipeline/explore.py
+++ b/pipeline/explore.py
@@ -1,0 +1,29 @@
+"""Exploratory data analysis helpers."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+import pandas as pd
+
+
+def basic_stats(events: pd.DataFrame) -> Dict[str, Any]:
+    """Return quick statistics of reconstructed event data.
+
+    The function is intentionally lightweight so it can run on limited
+    hardware.  It focuses on metrics that are often inspected by human
+    scalpers such as average spread and distribution of top of book sizes.
+    """
+    if events.empty:
+        return {}
+    stats: Dict[str, Any] = {
+        "events": len(events),
+        "start": events["ts"].iloc[0],
+        "end": events["ts"].iloc[-1],
+        "avg_spread": events["spread"].mean(),
+        "median_l1_bid": events["bid_vol_top"].median(),
+        "median_l1_ask": events["ask_vol_top"].median(),
+        "trade_through_bid": events["trade_through_bid"].sum(),
+        "trade_through_ask": events["trade_through_ask"].sum(),
+    }
+    return stats
+

--- a/pipeline/run_pipeline.py
+++ b/pipeline/run_pipeline.py
@@ -1,0 +1,75 @@
+"""High level pipeline orchestration for event-driven scalping research."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .data import load_raw_events
+from .explore import basic_stats
+from .signals import build_signals
+from .backtest import run_backtest
+
+
+def run(args: argparse.Namespace) -> None:
+    events = load_raw_events(
+        args.db_path,
+        start_time=args.start,
+        end_time=args.end,
+        max_depth=args.max_depth,
+    )
+    stats = basic_stats(events)
+    if not stats:
+        print("No events loaded; aborting.")
+        return
+    print("Loaded events", json.dumps(stats, default=str, indent=2))
+
+    ev_with_sig = build_signals(
+        events,
+        min_spread_ticks=args.min_spread_ticks,
+        min_volume_top=args.min_volume_top,
+    )
+    result = run_backtest(
+        ev_with_sig,
+        hold_sec=args.hold_sec,
+        queue_pos=args.queue_pos,
+        stop_ticks=args.stop_ticks,
+        tp_ticks=args.tp_ticks,
+        trail_ticks=args.trail_ticks,
+        entry_mode=args.entry_mode,
+    )
+    out = Path(args.output_dir); out.mkdir(parents=True, exist_ok=True)
+    ev_with_sig.to_parquet(out / "events.parquet", index=False)
+    result["trades"].to_csv(out / "trades.csv", index=False)
+    with open(out / "summary.json", "w") as f:
+        json.dump(result.get("summary", {}), f, indent=2)
+    print("Pipeline finished; results saved to", out)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="Run full scalping research pipeline")
+    ap.add_argument("db_path", help="Path to DuckDB file")
+    ap.add_argument("output_dir", help="Directory to store outputs")
+    ap.add_argument("--start", help="Start time UTC")
+    ap.add_argument("--end", help="End time UTC")
+    ap.add_argument("--max_depth", type=int, default=10)
+    ap.add_argument("--min_spread_ticks", type=int, default=1)
+    ap.add_argument("--min_volume_top", type=float, default=2.0)
+    ap.add_argument("--hold_sec", type=float, default=5.0)
+    ap.add_argument("--queue_pos", type=float, default=10.0)
+    ap.add_argument("--stop_ticks", type=float, default=0.0)
+    ap.add_argument("--tp_ticks", type=float, default=0.0)
+    ap.add_argument("--trail_ticks", type=float, default=0.0)
+    ap.add_argument("--entry_mode", choices=["maker", "taker", "pullback", "hybrid"], default="maker")
+    return ap
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pipeline/signals.py
+++ b/pipeline/signals.py
@@ -1,0 +1,56 @@
+"""Signal generation using event-driven primitives."""
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+from event_driven_strategy import derive_event_triggers
+
+
+def build_signals(
+    events: pd.DataFrame,
+    min_spread_ticks: int = 1,
+    min_volume_top: float = 2.0,
+    imb_win: int = 20,
+    imb_thr: float = 0.25,
+    cancel_z_win: int = 50,
+    cancel_z_thr: float = 2.0,
+    exhaust_frac: float = 0.6,
+    vac_drop_frac: float = 0.5,
+    micro_tilt_thr: float = 0.2,
+    min_gap_events: int = 30,
+    storm_skip: bool = False,
+    storm_threshold_ms: float = 5.0,
+    storm_lookback: int = 20,
+    edge_margin_ticks: float = 0.5,
+    w_imb: float = 2.0,
+    w_cancel: float = 1.0,
+    w_tilt: float = 1.0,
+    w_breakout: float = 2.5,
+) -> pd.DataFrame:
+    """Apply event trigger logic and return DataFrame with signals."""
+    if events.empty:
+        return events
+    return derive_event_triggers(
+        events,
+        min_spread_ticks=min_spread_ticks,
+        min_l1=min_volume_top,
+        imb_win=imb_win,
+        imb_thr=imb_thr,
+        cancel_z_win=cancel_z_win,
+        cancel_z_thr=cancel_z_thr,
+        exhaust_frac=exhaust_frac,
+        vac_drop_frac=vac_drop_frac,
+        micro_tilt_thr=micro_tilt_thr,
+        min_gap_events=min_gap_events,
+        storm_skip=storm_skip,
+        storm_threshold_ms=storm_threshold_ms,
+        storm_lookback=storm_lookback,
+        edge_margin_ticks=edge_margin_ticks,
+        w_imb=w_imb,
+        w_cancel=w_cancel,
+        w_tilt=w_tilt,
+        w_breakout=w_breakout,
+    )
+


### PR DESCRIPTION
## Summary
- introduce modular pipeline for event-driven scalping research
- add data loading, exploratory analysis, signal generation, and backtesting helpers
- document pipeline architecture and usage

## Testing
- `python -m py_compile pipeline/*.py event_driven_strategy.py`

------
https://chatgpt.com/codex/tasks/task_e_689e11769b008320bdb25f284f2f115c